### PR TITLE
Fixed NfcTag::getUid

### DIFF
--- a/NfcTag.cpp
+++ b/NfcTag.cpp
@@ -67,7 +67,7 @@ uint8_t NfcTag::getUidLength()
 
 void NfcTag::getUid(byte *uid, unsigned int uidLength)
 {
-    memcpy(_uid, uid, uidLength);
+    memcpy(uid, _uid, uidLength);
 }
 
 String NfcTag::getUidString()


### PR DESCRIPTION
This function will overwrite the internal _uid without returning it. I've fixed it.
Please review my changes.
