### PR TITLE
Fixed a type-o in payload length calculation for long records in NdefMessage constructor... please review and pull. thx!

### DIFF
--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -44,8 +44,11 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
         }
         else
         {
-            payloadLength = ((0xFF & data[++index]) << 24) | ((0xFF & data[++index]) << 26) |
-            ((0xFF & data[++index]) << 8) | (0xFF & data[++index]);
+            payloadLength =
+		((0xFF & data[++index]) << 24)
+		| ((0xFF & data[++index]) << 16)
+		| ((0xFF & data[++index]) << 8)
+		| (0xFF & data[++index]);
         }
 
         int idLength = 0;


### PR DESCRIPTION
NdefMessage constructor. Second byte was shifted left "26" bits, should
be "16" bits. This bug would not have affected records with payloads shorter
than 65,536 bytes in length, but good to fix it anyway.
