### PR TITLE
compiles with -Wall -Werror -std=c++11

### DIFF
--- a/MifareClassic.cpp
+++ b/MifareClassic.cpp
@@ -1,3 +1,4 @@
+#ifdef NDEF_SUPPORT_MIFARE_CLASSIC
 #include "MifareClassic.h"
 
 #define BLOCK_SIZE 16
@@ -447,3 +448,4 @@ boolean MifareClassic::write(NdefMessage& m, byte * uid, unsigned int uidLength)
 
     return true;
 }
+#endif

--- a/MifareClassic.cpp
+++ b/MifareClassic.cpp
@@ -36,13 +36,17 @@ NfcTag MifareClassic::read(byte *uid, unsigned int uidLength)
         }
         else
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Error. Failed read block "));Serial.println(currentBlock);
+#endif
             return NfcTag(uid, uidLength, MIFARE_CLASSIC);
         }
     }
     else
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("Tag is not NDEF formatted."));
+#endif
         // TODO set tag.isFormatted = false
         return NfcTag(uid, uidLength, MIFARE_CLASSIC);
     }
@@ -66,7 +70,9 @@ NfcTag MifareClassic::read(byte *uid, unsigned int uidLength)
             success = _nfcShield->mifareclassic_AuthenticateBlock(uid, uidLength, currentBlock, 0, key);
             if (!success)
             {
+#ifdef NDEF_USE_SERIAL
                 Serial.print(F("Error. Block Authentication failed for "));Serial.println(currentBlock);
+#endif
                 // TODO error handling
             }
         }
@@ -82,7 +88,9 @@ NfcTag MifareClassic::read(byte *uid, unsigned int uidLength)
         }
         else
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Read failed "));Serial.println(currentBlock);
+#endif
             // TODO handle errors here
         }
 
@@ -144,7 +152,9 @@ int MifareClassic::getNdefStartIndex(byte *data)
         }
         else
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print("Unknown TLV ");Serial.println(data[i], HEX);
+#endif
             return -2;
         }
     }
@@ -166,7 +176,9 @@ bool MifareClassic::decodeTlv(byte *data, int &messageLength, int &messageStartI
 
     if (i < 0 || data[i] != 0x3)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("Error. Can't decode message length."));
+#endif
         return false;
     }
     else
@@ -198,13 +210,17 @@ boolean MifareClassic::formatNDEF(byte * uid, unsigned int uidLength)
     boolean success = _nfcShield->mifareclassic_AuthenticateBlock (uid, uidLength, 0, 0, keya);
     if (!success)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("Unable to authenticate block 0 to enable card formatting!"));
+#endif
         return false;
     }
     success = _nfcShield->mifareclassic_FormatNDEF();
     if (!success)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("Unable to format the card for NDEF"));
+#endif
     }
     else
     {
@@ -216,31 +232,43 @@ boolean MifareClassic::formatNDEF(byte * uid, unsigned int uidLength)
                 {
                     if (!(_nfcShield->mifareclassic_WriteDataBlock (i, emptyNdefMesg)))
                     {
+#ifdef NDEF_USE_SERIAL
                         Serial.print(F("Unable to write block "));Serial.println(i);
+#endif
                     }
                 }
                 else
                 {
                     if (!(_nfcShield->mifareclassic_WriteDataBlock (i, sectorbuffer0)))
                     {
+#ifdef NDEF_USE_SERIAL
                         Serial.print(F("Unable to write block "));Serial.println(i);
+#endif
                     }
                 }
                 if (!(_nfcShield->mifareclassic_WriteDataBlock (i+1, sectorbuffer0)))
                 {
+#ifdef NDEF_USE_SERIAL
                     Serial.print(F("Unable to write block "));Serial.println(i+1);
+#endif
                 }
                 if (!(_nfcShield->mifareclassic_WriteDataBlock (i+2, sectorbuffer0)))
                 {
+#ifdef NDEF_USE_SERIAL
                     Serial.print(F("Unable to write block "));Serial.println(i+2);
+#endif
                 }
                 if (!(_nfcShield->mifareclassic_WriteDataBlock (i+3, sectorbuffer4)))
                 {
+#ifdef NDEF_USE_SERIAL
                     Serial.print(F("Unable to write block "));Serial.println(i+3);
+#endif
                 }
             } else {
                 unsigned int iii=uidLength;
+#ifdef NDEF_USE_SERIAL
                 Serial.print(F("Unable to authenticate block "));Serial.println(i);
+#endif
                 _nfcShield->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, (uint8_t*)&iii);
             }
         }
@@ -276,7 +304,9 @@ boolean MifareClassic::formatMifare(byte * uid, unsigned int uidLength)
         success = _nfcShield->mifareclassic_AuthenticateBlock (uid, uidLength, BLOCK_NUMBER_OF_SECTOR_TRAILER(idx), 1, (uint8_t *)KEY_DEFAULT_KEYAB);
         if (!success)
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Authentication failed for sector ")); Serial.println(idx);
+#endif
             return false;
         }
 
@@ -286,7 +316,9 @@ boolean MifareClassic::formatMifare(byte * uid, unsigned int uidLength)
             memset(blockBuffer, 0, sizeof(blockBuffer));
             if (!(_nfcShield->mifareclassic_WriteDataBlock((BLOCK_NUMBER_OF_SECTOR_TRAILER(idx)) - 2, blockBuffer)))
             {
+#ifdef NDEF_USE_SERIAL
                 Serial.print(F("Unable to write to sector ")); Serial.println(idx);
+#endif
             }
         }
         else
@@ -295,11 +327,15 @@ boolean MifareClassic::formatMifare(byte * uid, unsigned int uidLength)
             // this block has not to be overwritten for block 0. It contains Tag id and other unique data.
             if (!(_nfcShield->mifareclassic_WriteDataBlock((BLOCK_NUMBER_OF_SECTOR_TRAILER(idx)) - 3, blockBuffer)))
             {
+#ifdef NDEF_USE_SERIAL
                 Serial.print(F("Unable to write to sector ")); Serial.println(idx);
+#endif
             }
             if (!(_nfcShield->mifareclassic_WriteDataBlock((BLOCK_NUMBER_OF_SECTOR_TRAILER(idx)) - 2, blockBuffer)))
             {
+#ifdef NDEF_USE_SERIAL
                 Serial.print(F("Unable to write to sector ")); Serial.println(idx);
+#endif
             }
         }
 
@@ -307,7 +343,9 @@ boolean MifareClassic::formatMifare(byte * uid, unsigned int uidLength)
 
         if (!(_nfcShield->mifareclassic_WriteDataBlock((BLOCK_NUMBER_OF_SECTOR_TRAILER(idx)) - 1, blockBuffer)))
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Unable to write to sector ")); Serial.println(idx);
+#endif
         }
 
         // Step 3: Reset both keys to 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF
@@ -319,7 +357,9 @@ boolean MifareClassic::formatMifare(byte * uid, unsigned int uidLength)
         // Step 4: Write the trailer block
         if (!(_nfcShield->mifareclassic_WriteDataBlock((BLOCK_NUMBER_OF_SECTOR_TRAILER(idx)), blockBuffer)))
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Unable to write trailer block of sector ")); Serial.println(idx);
+#endif
         }
     }
     return true;
@@ -369,7 +409,9 @@ boolean MifareClassic::write(NdefMessage& m, byte * uid, unsigned int uidLength)
             int success = _nfcShield->mifareclassic_AuthenticateBlock(uid, uidLength, currentBlock, 0, key);
             if (!success)
             {
+#ifdef NDEF_USE_SERIAL
                 Serial.print(F("Error. Block Authentication failed for "));Serial.println(currentBlock);
+#endif
                 return false;
             }
         }
@@ -384,7 +426,9 @@ boolean MifareClassic::write(NdefMessage& m, byte * uid, unsigned int uidLength)
         }
         else
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Write failed "));Serial.println(currentBlock);
+#endif
             return false;
         }
         index += BLOCK_SIZE;

--- a/MifareClassic.cpp
+++ b/MifareClassic.cpp
@@ -357,7 +357,7 @@ boolean MifareClassic::write(NdefMessage& m, byte * uid, unsigned int uidLength)
     }
 
     // Write to tag
-    int index = 0;
+    unsigned int index = 0;
     int currentBlock = 4;
     uint8_t key[6] = { 0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7 }; // this is Sector 1 - 15 key
 

--- a/MifareClassic.h
+++ b/MifareClassic.h
@@ -1,6 +1,8 @@
 #ifndef MifareClassic_h
 #define MifareClassic_h
 
+#ifdef NDEF_SUPPORT_MIFARE_CLASSIC
+
 #include <Due.h>
 #include <PN532.h>
 #include <Ndef.h>
@@ -22,4 +24,5 @@ class MifareClassic
         bool decodeTlv(byte *data, int &messageLength, int &messageStartIndex);
 };
 
+#endif
 #endif

--- a/MifareUltralight.cpp
+++ b/MifareUltralight.cpp
@@ -25,7 +25,9 @@ NfcTag MifareUltralight::read(byte * uid, unsigned int uidLength)
 {
     if (isUnformatted())
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("WARNING: Tag is not formatted."));
+#endif
         return NfcTag(uid, uidLength, NFC_FORUM_TAG_TYPE_2);
     }
 
@@ -56,7 +58,9 @@ NfcTag MifareUltralight::read(byte * uid, unsigned int uidLength)
         }
         else
         {
+#ifdef NDEF_USE_SERIAL
             Serial.print(F("Read failed "));Serial.println(page);
+#endif
             // TODO error handling
             messageLength = 0;
             break;
@@ -86,7 +90,9 @@ boolean MifareUltralight::isUnformatted()
     }
     else
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("Error. Failed read page "));Serial.println(page);
+#endif
         return false;
     }
 }
@@ -166,7 +172,9 @@ boolean MifareUltralight::write(NdefMessage& m, byte * uid, unsigned int uidLeng
 {
     if (isUnformatted())
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("WARNING: Tag is not formatted."));
+#endif
         return false;
     }
     readCapabilityContainer(); // meta info for tag

--- a/Ndef.cpp
+++ b/Ndef.cpp
@@ -3,7 +3,7 @@
 // Borrowed from Adafruit_NFCShield_I2C
 void PrintHex(const byte * data, const long numBytes)
 {
-  uint32_t szPos;
+  int32_t szPos;
   for (szPos=0; szPos < numBytes; szPos++)
   {
     Serial.print("0x");
@@ -22,7 +22,7 @@ void PrintHex(const byte * data, const long numBytes)
 // Borrowed from Adafruit_NFCShield_I2C
 void PrintHexChar(const byte * data, const long numBytes)
 {
-  uint32_t szPos;
+  int32_t szPos;
   for (szPos=0; szPos < numBytes; szPos++)
   {
     // Append leading 0 for small values

--- a/Ndef.cpp
+++ b/Ndef.cpp
@@ -1,5 +1,6 @@
 #include "Ndef.h"
 
+#ifdef NDEF_USE_SERIAL
 // Borrowed from Adafruit_NFCShield_I2C
 void PrintHex(const byte * data, const long numBytes)
 {
@@ -55,3 +56,4 @@ void DumpHex(const byte * data, const long numBytes, const unsigned int blockSiz
         data += blockSize;
     }
 }
+#endif

--- a/Ndef.h
+++ b/Ndef.h
@@ -7,8 +7,6 @@
 
 #include <Arduino.h>
 
-#define NULL (void *)0
-
 void PrintHex(const byte *data, const long numBytes);
 void PrintHexChar(const byte *data, const long numBytes);
 void DumpHex(const byte *data, const long numBytes, const int blockSize);

--- a/Ndef.h
+++ b/Ndef.h
@@ -7,8 +7,10 @@
 
 #include <Arduino.h>
 
+#ifdef NDEF_USE_SERIAL
 void PrintHex(const byte *data, const long numBytes);
 void PrintHexChar(const byte *data, const long numBytes);
 void DumpHex(const byte *data, const long numBytes, const int blockSize);
 
+#endif
 #endif

--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -23,11 +23,11 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
         // decode tnf - first byte is tnf with bit flags
         // see the NFDEF spec for more info
         byte tnf_byte = data[index];
-        bool mb = (tnf_byte & 0x80) != 0;
-        bool me = (tnf_byte & 0x40) != 0;
-        bool cf = (tnf_byte & 0x20) != 0;
-        bool sr = (tnf_byte & 0x10) != 0;
-        bool il = (tnf_byte & 0x8) != 0;
+        // bool mb = tnf_byte & 0x80;
+        bool me = tnf_byte & 0x40;
+        // bool cf = tnf_byte & 0x20;
+        bool sr = tnf_byte & 0x10;
+        bool il = tnf_byte & 0x8;
         byte tnf = (tnf_byte & 0x7);
 
         NdefRecord record = NdefRecord();
@@ -36,7 +36,7 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
         index++;
         int typeLength = data[index];
 
-        int payloadLength = 0;
+        uint32_t payloadLength = 0;
         if (sr)
         {
             index++;
@@ -44,11 +44,12 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
         }
         else
         {
-            payloadLength =
-		((0xFF & data[++index]) << 24)
-		| ((0xFF & data[++index]) << 16)
-		| ((0xFF & data[++index]) << 8)
-		| (0xFF & data[++index]);
+        payloadLength =
+              (static_cast<uint32_t>(data[index])   << 24)
+            | (static_cast<uint32_t>(data[index+1]) << 16)
+            | (static_cast<uint32_t>(data[index+2]) << 8)
+            |  static_cast<uint32_t>(data[index+3]);
+        index += 4;
         }
 
         int idLength = 0;
@@ -82,7 +83,7 @@ NdefMessage::NdefMessage(const NdefMessage& rhs)
 {
 
     _recordCount = rhs._recordCount;
-    for (int i = 0; i < _recordCount; i++)
+    for (unsigned int i = 0; i < _recordCount; i++)
     {
         _records[i] = rhs._records[i];
     }
@@ -100,14 +101,14 @@ NdefMessage& NdefMessage::operator=(const NdefMessage& rhs)
     {
 
         // delete existing records
-        for (int i = 0; i < _recordCount; i++)
+        for (unsigned int i = 0; i < _recordCount; i++)
         {
             // TODO Dave: is this the right way to delete existing records?
             _records[i] = NdefRecord();
         }
 
         _recordCount = rhs._recordCount;
-        for (int i = 0; i < _recordCount; i++)
+        for (unsigned int i = 0; i < _recordCount; i++)
         {
             _records[i] = rhs._records[i];
         }
@@ -123,7 +124,7 @@ unsigned int NdefMessage::getRecordCount()
 int NdefMessage::getEncodedSize()
 {
     int size = 0;
-    for (int i = 0; i < _recordCount; i++)
+    for (unsigned int i = 0; i < _recordCount; i++)
     {
         size += _records[i].getEncodedSize();
     }
@@ -136,7 +137,7 @@ void NdefMessage::encode(uint8_t* data)
     // assert sizeof(data) >= getEncodedSize()
     uint8_t* data_ptr = &data[0];
 
-    for (int i = 0; i < _recordCount; i++)
+    for (unsigned int i = 0; i < _recordCount; i++)
     {
         _records[i].encode(data_ptr, i == 0, (i + 1) == _recordCount);
         // TODO can NdefRecord.encode return the record size?
@@ -245,7 +246,7 @@ void NdefMessage::addEmptyRecord()
 
 NdefRecord NdefMessage::getRecord(int index)
 {
-    if (index > -1 && index < _recordCount)
+    if (index > -1 && index < static_cast<int>(_recordCount))
     {
         return _records[index];
     }
@@ -266,8 +267,7 @@ void NdefMessage::print()
     _recordCount == 1 ? Serial.print(", ") : Serial.print("s, ");
     Serial.print(getEncodedSize());Serial.println(F(" bytes"));
 
-    int i;
-    for (i = 0; i < _recordCount; i++)
+    for (unsigned int i = 0; i < _recordCount; i++)
     {
          _records[i].print();
     }

--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -44,12 +44,12 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
         }
         else
         {
-        payloadLength =
-              (static_cast<uint32_t>(data[index])   << 24)
-            | (static_cast<uint32_t>(data[index+1]) << 16)
-            | (static_cast<uint32_t>(data[index+2]) << 8)
-            |  static_cast<uint32_t>(data[index+3]);
-        index += 4;
+            payloadLength =
+                  (static_cast<uint32_t>(data[index])   << 24)
+                | (static_cast<uint32_t>(data[index+1]) << 16)
+                | (static_cast<uint32_t>(data[index+2]) << 8)
+                |  static_cast<uint32_t>(data[index+3]);
+            index += 4;
         }
 
         int idLength = 0;

--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -157,7 +157,9 @@ boolean NdefMessage::addRecord(NdefRecord& record)
     }
     else
     {
+#ifdef NDEF_USE_SERIAL
         Serial.println(F("WARNING: Too many records. Increase MAX_NDEF_RECORDS."));
+#endif
         return false;
     }
 }
@@ -261,6 +263,7 @@ NdefRecord NdefMessage::operator[](int index)
     return getRecord(index);
 }
 
+#ifdef NDEF_USE_SERIAL
 void NdefMessage::print()
 {
     Serial.print(F("\nNDEF Message "));Serial.print(_recordCount);Serial.print(F(" record"));
@@ -272,3 +275,4 @@ void NdefMessage::print()
          _records[i].print();
     }
 }
+#endif

--- a/NdefMessage.h
+++ b/NdefMessage.h
@@ -30,7 +30,9 @@ class NdefMessage
         NdefRecord getRecord(int index);
         NdefRecord operator[](int index);
 
+#ifdef NDEF_USE_SERIAL
         void print();
+#endif
     private:
         NdefRecord _records[MAX_NDEF_RECORDS];
         unsigned int _recordCount;

--- a/NdefRecord.cpp
+++ b/NdefRecord.cpp
@@ -301,6 +301,7 @@ void NdefRecord::setId(const byte * id, const unsigned int numBytes)
     memcpy(_id, id, numBytes);
     _idLength = numBytes;
 }
+#ifdef NDEF_USE_SERIAL
 
 void NdefRecord::print()
 {
@@ -350,3 +351,4 @@ void NdefRecord::print()
     Serial.print(F("    Record is "));Serial.print(getEncodedSize());Serial.println(" bytes");
 
 }
+#endif

--- a/NdefRecord.h
+++ b/NdefRecord.h
@@ -43,7 +43,9 @@ class NdefRecord
         void setPayload(const byte *payload, const int numBytes);
         void setId(const byte *id, const unsigned int numBytes);
 
+#ifdef NDEF_USE_SERIAL
         void print();
+#endif
     private:
         byte getTnfByte(bool firstRecord, bool lastRecord);
         byte _tnf; // 3 bit

--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -62,12 +62,14 @@ boolean NfcAdapter::erase()
 boolean NfcAdapter::format()
 {
     boolean success;
+#ifdef NDEF_SUPPORT_MIFARE_CLASSIC
     if (uidLength == 4)
     {
         MifareClassic mifareClassic = MifareClassic(*shield);
         success = mifareClassic.formatNDEF(uid, uidLength);
     }
     else
+#endif
     {
 #ifdef NDEF_USE_SERIAL
         Serial.print(F("Unsupported Tag."));
@@ -81,6 +83,7 @@ boolean NfcAdapter::clean()
 {
     uint8_t type = guessTagType();
 
+#ifdef NDEF_SUPPORT_MIFARE_CLASSIC
     if (type == TAG_TYPE_MIFARE_CLASSIC)
     {
         #ifdef NDEF_DEBUG
@@ -89,7 +92,9 @@ boolean NfcAdapter::clean()
         MifareClassic mifareClassic = MifareClassic(*shield);
         return mifareClassic.formatMifare(uid, uidLength);
     }
-    else if (type == TAG_TYPE_2)
+    else
+#endif
+    if (type == TAG_TYPE_2)
     {
         #ifdef NDEF_DEBUG
         Serial.println(F("Cleaning Mifare Ultralight"));
@@ -112,6 +117,7 @@ NfcTag NfcAdapter::read()
 {
     uint8_t type = guessTagType();
 
+#ifdef NDEF_SUPPORT_MIFARE_CLASSIC
     if (type == TAG_TYPE_MIFARE_CLASSIC)
     {
         #ifdef NDEF_DEBUG
@@ -121,6 +127,7 @@ NfcTag NfcAdapter::read()
         return mifareClassic.read(uid, uidLength);
     }
     else
+#endif
     if (type == TAG_TYPE_2)
     {
         #ifdef NDEF_DEBUG
@@ -150,6 +157,7 @@ boolean NfcAdapter::write(NdefMessage& ndefMessage)
     boolean success;
     uint8_t type = guessTagType();
 
+#ifdef NDEF_SUPPORT_MIFARE_CLASSIC
     if (type == TAG_TYPE_MIFARE_CLASSIC)
     {
         #ifdef NDEF_DEBUG
@@ -158,7 +166,9 @@ boolean NfcAdapter::write(NdefMessage& ndefMessage)
         MifareClassic mifareClassic = MifareClassic(*shield);
         success = mifareClassic.write(ndefMessage, uid, uidLength);
     }
-    else if (type == TAG_TYPE_2)
+    else
+#endif
+    if (type == TAG_TYPE_2)
     {
         #ifdef NDEF_DEBUG
         Serial.println(F("Writing Mifare Ultralight"));

--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -18,15 +18,19 @@ void NfcAdapter::begin(boolean verbose)
 
     if (! versiondata)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("Didn't find PN53x board"));
+#endif
         while (1); // halt
     }
 
     if (verbose)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("Found chip PN5")); Serial.println((versiondata>>24) & 0xFF, HEX);
         Serial.print(F("Firmware ver. ")); Serial.print((versiondata>>16) & 0xFF, DEC);
         Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
+#endif
     }
     // configure board to read RFID tags
     shield->SAMConfig();
@@ -65,7 +69,9 @@ boolean NfcAdapter::format()
     }
     else
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("Unsupported Tag."));
+#endif
         success = false;
     }
     return success;
@@ -93,7 +99,9 @@ boolean NfcAdapter::clean()
     }
     else
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("No driver for card type "));Serial.println(type);
+#endif
         return false;
     }
 
@@ -123,7 +131,9 @@ NfcTag NfcAdapter::read()
     }
     else if (type == TAG_TYPE_UNKNOWN)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("Can not determine tag type"));
+#endif
         return NfcTag(uid, uidLength);
     }
     else
@@ -158,12 +168,16 @@ boolean NfcAdapter::write(NdefMessage& ndefMessage)
     }
     else if (type == TAG_TYPE_UNKNOWN)
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("Can not determine tag type"));
+#endif
         success = false;
     }
     else
     {
+#ifdef NDEF_USE_SERIAL
         Serial.print(F("No driver for card type "));Serial.println(type);
+#endif
         success = false;
     }
 

--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -50,7 +50,6 @@ boolean NfcAdapter::tagPresent(unsigned long timeout)
 
 boolean NfcAdapter::erase()
 {
-    boolean success;
     NdefMessage message = NdefMessage();
     message.addEmptyRecord();
     return write(message);
@@ -113,7 +112,8 @@ NfcTag NfcAdapter::read()
         MifareClassic mifareClassic = MifareClassic(*shield);
         return mifareClassic.read(uid, uidLength);
     }
-    else if (type == TAG_TYPE_2)
+    else
+    if (type == TAG_TYPE_2)
     {
         #ifdef NDEF_DEBUG
         Serial.println(F("Reading Mifare Ultralight"));
@@ -128,7 +128,7 @@ NfcTag NfcAdapter::read()
     }
     else
     {
-        Serial.print(F("No driver for card type "));Serial.println(type);
+        // Serial.print(F("No driver for card type "));Serial.println(type);
         // TODO should set type here
         return NfcTag(uid, uidLength);
     }

--- a/NfcTag.cpp
+++ b/NfcTag.cpp
@@ -105,6 +105,7 @@ NdefMessage NfcTag::getNdefMessage()
 {
     return *_ndefMessage;
 }
+#ifdef NDEF_USE_SERIAL
 
 void NfcTag::print()
 {
@@ -119,3 +120,4 @@ void NfcTag::print()
         _ndefMessage->print();
     }
 }
+#endif

--- a/NfcTag.cpp
+++ b/NfcTag.cpp
@@ -73,7 +73,7 @@ void NfcTag::getUid(byte *uid, unsigned int uidLength)
 String NfcTag::getUidString()
 {
     String uidString = "";
-    for (int i = 0; i < _uidLength; i++)
+    for (unsigned int i = 0; i < _uidLength; i++)
     {
         if (i > 0)
         {

--- a/NfcTag.h
+++ b/NfcTag.h
@@ -21,7 +21,9 @@ class NfcTag
         String getTagType();
         boolean hasNdefMessage();
         NdefMessage getNdefMessage();
+#ifdef NDEF_USE_SERIAL
         void print();
+#endif
     private:
         byte *_uid;
         unsigned int _uidLength;

--- a/tests/NdefMemoryTest/NdefMemoryTest.ino
+++ b/tests/NdefMemoryTest/NdefMemoryTest.ino
@@ -2,7 +2,7 @@
 #include <PN532.h>
 #include <NdefMessage.h>
 #include <NdefRecord.h>
-  #include <ArduinoUnit.h>
+#include <ArduinoUnit.h>
 
 void leakCheck(void (*callback)())
 {
@@ -30,7 +30,9 @@ void record()
 void emptyRecord()
 {
   NdefRecord* r = new NdefRecord();
+#ifdef NDEF_USE_SERIAL
   r->print();
+#endif
   delete r;
 }
 
@@ -42,7 +44,9 @@ void textRecord()
   r->setType(type, sizeof(type));
   uint8_t payload[] = { 0x1A, 0x1B, 0x1C };
   r->setPayload(payload, sizeof(payload));
+#ifdef NDEF_USE_SERIAL
   r->print();
+#endif
   delete r;
 }
 
@@ -66,7 +70,9 @@ void emptyMessage()
 void printEmptyMessage()
 {
   NdefMessage* m = new NdefMessage();
+#ifdef NDEF_USE_SERIAL
   m->print();
+#endif
   delete m;
 }
 
@@ -74,14 +80,18 @@ void printEmptyMessage()
 void printEmptyMessageNoNew()
 {
   NdefMessage m = NdefMessage();
+#ifdef NDEF_USE_SERIAL
   m.print();
+#endif
 }
 
 void messageWithTextRecord()
 {
   NdefMessage m = NdefMessage();
   m.addTextRecord("foo");
+#ifdef NDEF_USE_SERIAL
   m.print();
+#endif
 }
 
 void messageWithEmptyRecord()
@@ -89,7 +99,9 @@ void messageWithEmptyRecord()
   NdefMessage m = NdefMessage();
   NdefRecord r = NdefRecord();
   m.addRecord(r);
+#ifdef NDEF_USE_SERIAL
   m.print();
+#endif
 }
 
 void messageWithoutHelper()
@@ -102,7 +114,9 @@ void messageWithoutHelper()
   uint8_t payload[] = { 0x02, 0x65, 0x6E, 0x66, 0x6F, 0x6F };
   r.setPayload(payload, sizeof(payload));
   m.addRecord(r);
+#ifdef NDEF_USE_SERIAL
   m.print();
+#endif
 }
 
 void messageWithId()
@@ -117,28 +131,36 @@ void messageWithId()
   uint8_t id[] = { 0x0, 0x0, 0x0 };
   r.setId(id, sizeof(id));
   m.addRecord(r);
+#ifdef NDEF_USE_SERIAL
   m.print();
+#endif
 }
 
 void message80()
 {
   NdefMessage message = NdefMessage();
   message.addTextRecord("This record is 80 characters.X01234567890123456789012345678901234567890123456789");
+#ifdef NDEF_USE_SERIAL
   //message.print();
+#endif
 }
 
 void message100()
 {
   NdefMessage message = NdefMessage();
   message.addTextRecord("This record is 100 characters.0123456789012345678901234567890123456789012345678901234567890123456789");
+#ifdef NDEF_USE_SERIAL
   //message.print();
+#endif
 }
 
 void message120()
 {
   NdefMessage message = NdefMessage();
   message.addTextRecord("This record is 120 characters.012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789");
+#ifdef NDEF_USE_SERIAL
   //message.print();
+#endif
 }
 
 void setup() {

--- a/tests/NfcTagTest/NfcTagTest.ino
+++ b/tests/NfcTagTest/NfcTagTest.ino
@@ -14,16 +14,16 @@ test(getUid)
   byte uidFromTag[sizeof(uid)]; 
 
   NfcTag tag = NfcTag(uid, sizeof(uid));
-  
+
   assertEqual(sizeof(uid), tag.getUidLength());
-  
+
   tag.getUid(uidFromTag, sizeof(uidFromTag));
-  
+
   // make sure the 2 uids are the same
   for (int i = 0; i < sizeof(uid); i++) {
     assertEqual(uid[i], uidFromTag[i]);
   }
-  
+
   // check contents, to ensure the original uid wasn't overwritten
   assertEqual(0x00, uid[0]);
   assertEqual(0xFF, uid[1]);


### PR DESCRIPTION
For the most part, this fixes some signed/unsigned comparisons.
It also removes the (illegal in C++11) redefinement of `NULL` and fixes multiple cases of (technically) undefined behavior in the computation of `payloadLength` (which probably won't affect the resulting code, but the warnings are valid by the standard).
