### PR TITLE
Added method to create an Android Application Record (AAR)

### DIFF
--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -235,6 +235,20 @@ void NdefMessage::addUriRecord(String uri)
     delete(r);
 }
 
+void NdefMessage::addAndroidApplicationRecord(char *packageName)
+{
+    NdefRecord* r = new NdefRecord();
+    r->setTnf(TNF_EXTERNAL_TYPE);
+
+    char *RTD_AAR = "android.com:pkg"; // TODO this should be a constant or preprocessor
+    r->setType((uint8_t *)RTD_AAR, strlen(RTD_AAR));
+
+    r->setPayload((uint8_t *)packageName, strlen(packageName));
+
+    addRecord(*r);
+    delete(r);
+}
+
 void NdefMessage::addEmptyRecord()
 {
     NdefRecord* r = new NdefRecord();

--- a/NdefMessage.h
+++ b/NdefMessage.h
@@ -24,6 +24,16 @@ class NdefMessage
         void addTextRecord(String text);
         void addTextRecord(String text, String encoding);
         void addUriRecord(String uri);
+
+		/** 
+		 * Creates an Android Application Record (AAR) http://developer.android.com/guide/topics/connectivity/nfc/nfc.html#aar
+		 * Use an AAR record to cause a P2P message pushed to your Android phone to launch your app even if it's not running.
+		 * Note, Android version must be >= 4.0 and your app must have the package you pass to this method
+		 * 
+		 * @param packageName example: "com.acme.myapp" 
+		 */
+        void addAndroidApplicationRecord(char *packageName);
+
         void addEmptyRecord();
 
         unsigned int getRecordCount();


### PR DESCRIPTION
Use an AAR record to cause a P2P message pushed to your Android phone to launch your app even if it's not running. Just pass in your app's package name, i.e. "com.acme.myapp". Works on Android 4.0+

http://developer.android.com/guide/topics/connectivity/nfc/nfc.html#aar