### PR TITLE
Fixed memory leak in NdefMessage and added RFField control functions

### DIFF
--- a/MifareClassic.cpp
+++ b/MifareClassic.cpp
@@ -74,7 +74,7 @@ NfcTag MifareClassic::read(byte *uid, unsigned int uidLength)
 #ifdef NDEF_USE_SERIAL
                 Serial.print(F("Error. Block Authentication failed for "));Serial.println(currentBlock);
 #endif
-                // TODO error handling
+                return NfcTag(uid, uidLength, "ERROR"); // TODO should the error message go in NfcTag?
             }
         }
 
@@ -92,7 +92,7 @@ NfcTag MifareClassic::read(byte *uid, unsigned int uidLength)
 #ifdef NDEF_USE_SERIAL
             Serial.print(F("Read failed "));Serial.println(currentBlock);
 #endif
-            // TODO handle errors here
+            return NfcTag(uid, uidLength, "ERROR"); // TODO should the error message go in NfcTag?
         }
 
         index += BLOCK_SIZE;

--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -17,7 +17,7 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
 
     int index = 0;
 
-    while (index <= numBytes)
+    while (index < numBytes)
     {
         // decode tnf - first byte is tnf with bit flags
         // see the NFDEF spec for more info

--- a/NdefMessage.cpp
+++ b/NdefMessage.cpp
@@ -19,7 +19,6 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
 
     while (index <= numBytes)
     {
-
         // decode tnf - first byte is tnf with bit flags
         // see the NFDEF spec for more info
         byte tnf_byte = data[index];
@@ -81,36 +80,34 @@ NdefMessage::NdefMessage(const byte * data, const int numBytes)
 
 NdefMessage::NdefMessage(const NdefMessage& rhs)
 {
-
-    _recordCount = rhs._recordCount;
-    for (unsigned int i = 0; i < _recordCount; i++)
+    _recordCount = 0;
+    for (int i = 0; i < rhs._recordCount; i++)
     {
-        _records[i] = rhs._records[i];
+        addRecord(*(rhs._records[i]));
     }
-
 }
 
 NdefMessage::~NdefMessage()
 {
+    for (int i = 0; i < _recordCount; i++)
+    {
+        delete(_records[i]);
+    }
 }
 
 NdefMessage& NdefMessage::operator=(const NdefMessage& rhs)
 {
-
     if (this != &rhs)
     {
-
-        // delete existing records
-        for (unsigned int i = 0; i < _recordCount; i++)
+        for (int i = 0; i < _recordCount; i++)
         {
-            // TODO Dave: is this the right way to delete existing records?
-            _records[i] = NdefRecord();
+            delete(_records[i]);
+            _records[i] = (NdefRecord*)NULL;
         }
-
-        _recordCount = rhs._recordCount;
-        for (unsigned int i = 0; i < _recordCount; i++)
+        _recordCount = 0;
+        for (int i = 0; i < rhs._recordCount; i++)
         {
-            _records[i] = rhs._records[i];
+            addRecord(*(rhs._records[i]));
         }
     }
     return *this;
@@ -126,7 +123,7 @@ int NdefMessage::getEncodedSize()
     int size = 0;
     for (unsigned int i = 0; i < _recordCount; i++)
     {
-        size += _records[i].getEncodedSize();
+        size += _records[i]->getEncodedSize();
     }
     return size;
 }
@@ -139,9 +136,9 @@ void NdefMessage::encode(uint8_t* data)
 
     for (unsigned int i = 0; i < _recordCount; i++)
     {
-        _records[i].encode(data_ptr, i == 0, (i + 1) == _recordCount);
+        _records[i]->encode(data_ptr, i == 0, (i + 1) == _recordCount);
         // TODO can NdefRecord.encode return the record size?
-        data_ptr += _records[i].getEncodedSize();
+        data_ptr += _records[i]->getEncodedSize();
     }
 
 }
@@ -151,7 +148,7 @@ boolean NdefMessage::addRecord(NdefRecord& record)
 
     if (_recordCount < MAX_NDEF_RECORDS)
     {
-        _records[_recordCount] = record;
+        _records[_recordCount] = new NdefRecord(record);
         _recordCount++;
         return true;
     }
@@ -217,11 +214,11 @@ void NdefMessage::addTextRecord(String text, String encoding)
 
 void NdefMessage::addUriRecord(String uri)
 {
-    NdefRecord* r = new NdefRecord();
-    r->setTnf(TNF_WELL_KNOWN);
+    NdefRecord r = NdefRecord();
+    r.setTnf(TNF_WELL_KNOWN);
 
     uint8_t RTD_URI[1] = { 0x55 }; // TODO this should be a constant or preprocessor
-    r->setType(RTD_URI, sizeof(RTD_URI));
+    r.setType(RTD_URI, sizeof(RTD_URI));
 
     // X is a placeholder for identifier code
     String payloadString = "X" + uri;
@@ -232,33 +229,28 @@ void NdefMessage::addUriRecord(String uri)
     // add identifier code 0x0, meaning no prefix substitution
     payload[0] = 0x0;
 
-    r->setPayload(payload, payloadString.length());
+    r.setPayload(payload, payloadString.length());
 
-    addRecord(*r);
-    delete(r);
+    addRecord(r);
 }
 
 void NdefMessage::addEmptyRecord()
 {
-    NdefRecord* r = new NdefRecord();
-    r->setTnf(TNF_EMPTY);
-    addRecord(*r);
-    delete(r);
+    NdefRecord r = NdefRecord();
+    r.setTnf(TNF_EMPTY);
+    addRecord(r);
 }
 
-NdefRecord NdefMessage::getRecord(int index)
+NdefRecord NdefMessage::getRecord(unsigned int index)
 {
-    if (index > -1 && index < static_cast<int>(_recordCount))
+    if (index < MAX_NDEF_RECORDS)
     {
-        return _records[index];
+        return *(_records[index]);
     }
-    else
-    {
-        return NdefRecord(); // would rather return NULL
-    }
+    return NdefRecord(); // would rather return NULL
 }
 
-NdefRecord NdefMessage::operator[](int index)
+NdefRecord NdefMessage::operator[](unsigned int index)
 {
     return getRecord(index);
 }
@@ -272,7 +264,7 @@ void NdefMessage::print()
 
     for (unsigned int i = 0; i < _recordCount; i++)
     {
-         _records[i].print();
+         _records[i]->print();
     }
 }
 #endif

--- a/NdefMessage.h
+++ b/NdefMessage.h
@@ -27,14 +27,14 @@ class NdefMessage
         void addEmptyRecord();
 
         unsigned int getRecordCount();
-        NdefRecord getRecord(int index);
-        NdefRecord operator[](int index);
+        NdefRecord getRecord(unsigned int index);
+        NdefRecord operator[](unsigned int index);
 
 #ifdef NDEF_USE_SERIAL
         void print();
 #endif
     private:
-        NdefRecord _records[MAX_NDEF_RECORDS];
+        NdefRecord* _records[MAX_NDEF_RECORDS];
         unsigned int _recordCount;
 };
 

--- a/NdefRecord.cpp
+++ b/NdefRecord.cpp
@@ -2,7 +2,6 @@
 
 NdefRecord::NdefRecord()
 {
-    //Serial.println("NdefRecord Constructor 1");
     _tnf = 0;
     _typeLength = 0;
     _payloadLength = 0;
@@ -14,8 +13,6 @@ NdefRecord::NdefRecord()
 
 NdefRecord::NdefRecord(const NdefRecord& rhs)
 {
-    //Serial.println("NdefRecord Constructor 2 (copy)");
-
     _tnf = rhs._tnf;
     _typeLength = rhs._typeLength;
     _payloadLength = rhs._payloadLength;
@@ -26,43 +23,52 @@ NdefRecord::NdefRecord(const NdefRecord& rhs)
 
     if (_typeLength)
     {
-        _type = (byte*)malloc(_typeLength);
+        if (!(_type = (byte*)malloc(_typeLength)))
+        {
+            goto cleanup;
+        }
         memcpy(_type, rhs._type, _typeLength);
     }
 
     if (_payloadLength)
     {
-        _payload = (byte*)malloc(_payloadLength);
+        if (!(_payload = (byte*)malloc(_payloadLength)))
+        {
+            goto cleanup;
+        }
         memcpy(_payload, rhs._payload, _payloadLength);
     }
 
     if (_idLength)
     {
-        _id = (byte*)malloc(_idLength);
+        if (!(_id = (byte*)malloc(_idLength)))
+        {
+            goto cleanup;
+        }
         memcpy(_id, rhs._id, _idLength);
     }
+    return;
 
+cleanup:
+    free(_type);
+    free(_payload);
+    free(_id);
+    _tnf = 0;
+    _typeLength = 0;
+    _payloadLength = 0;
+    _idLength = 0;
+    _type = (byte *)NULL;
+    _payload = (byte *)NULL;
+    _id = (byte *)NULL;
 }
 
 // TODO NdefRecord::NdefRecord(tnf, type, payload, id)
 
 NdefRecord::~NdefRecord()
 {
-    //Serial.println("NdefRecord Destructor");
-    if (_typeLength)
-    {
-        free(_type);
-    }
-
-    if (_payloadLength)
-    {
-        free(_payload);
-    }
-
-    if (_idLength)
-    {
-        free(_id);
-    }
+    free(_type);
+    free(_payload);
+    free(_id);
 }
 
 NdefRecord& NdefRecord::operator=(const NdefRecord& rhs)
@@ -72,20 +78,9 @@ NdefRecord& NdefRecord::operator=(const NdefRecord& rhs)
     if (this != &rhs)
     {
         // free existing
-        if (_typeLength)
-        {
-            free(_type);
-        }
-
-        if (_payloadLength)
-        {
-            free(_payload);
-        }
-
-        if (_idLength)
-        {
-            free(_id);
-        }
+        free(_type);
+        free(_payload);
+        free(_id);
 
         _tnf = rhs._tnf;
         _typeLength = rhs._typeLength;
@@ -94,22 +89,44 @@ NdefRecord& NdefRecord::operator=(const NdefRecord& rhs)
 
         if (_typeLength)
         {
-            _type = (byte*)malloc(_typeLength);
+            if (!(_type = (byte*)malloc(_typeLength)))
+            {
+                goto cleanup;
+            }
             memcpy(_type, rhs._type, _typeLength);
         }
 
         if (_payloadLength)
         {
-            _payload = (byte*)malloc(_payloadLength);
+            if (!(_payload = (byte*)malloc(_payloadLength)))
+            {
+                goto cleanup;
+            }
             memcpy(_payload, rhs._payload, _payloadLength);
         }
 
         if (_idLength)
         {
-            _id = (byte*)malloc(_idLength);
+            if (!(_id = (byte*)malloc(_idLength)))
+            {
+                goto cleanup;
+            }
             memcpy(_id, rhs._id, _idLength);
         }
     }
+    return *this;
+
+cleanup:
+    free(_type);
+    free(_payload);
+    free(_id);
+    _tnf = 0;
+    _typeLength = 0;
+    _payloadLength = 0;
+    _idLength = 0;
+    _type = (byte *)NULL;
+    _payload = (byte *)NULL;
+    _id = (byte *)NULL;
     return *this;
 }
 
@@ -249,14 +266,14 @@ void NdefRecord::getType(uint8_t* type)
 
 void NdefRecord::setType(const byte * type, const unsigned int numBytes)
 {
-    if(_typeLength)
-    {
-        free(_type);
-    }
+    free(_type);
+    _typeLength = 0;
 
-    _type = (uint8_t*)malloc(numBytes);
-    memcpy(_type, type, numBytes);
-    _typeLength = numBytes;
+    if (_type = (uint8_t*)malloc(numBytes))
+    {
+        memcpy(_type, type, numBytes);
+        _typeLength = numBytes;
+    }
 }
 
 // assumes the caller sized payload properly
@@ -267,14 +284,14 @@ void NdefRecord::getPayload(byte *payload)
 
 void NdefRecord::setPayload(const byte * payload, const int numBytes)
 {
-    if (_payloadLength)
-    {
-        free(_payload);
-    }
+    free(_payload);
+    _payloadLength = 0;
 
-    _payload = (byte*)malloc(numBytes);
-    memcpy(_payload, payload, numBytes);
-    _payloadLength = numBytes;
+    if (_payload = (byte*)malloc(numBytes))
+    {
+        memcpy(_payload, payload, numBytes);
+        _payloadLength = numBytes;        
+    }
 }
 
 String NdefRecord::getId()
@@ -292,14 +309,14 @@ void NdefRecord::getId(byte *id)
 
 void NdefRecord::setId(const byte * id, const unsigned int numBytes)
 {
-    if (_idLength)
-    {
-        free(_id);
-    }
+    free(_id);
+    _idLength = 0;
 
-    _id = (byte*)malloc(numBytes);
-    memcpy(_id, id, numBytes);
-    _idLength = numBytes;
+    if (_id = (byte*)malloc(numBytes))
+    {
+        memcpy(_id, id, numBytes);
+        _idLength = numBytes;
+    }
 }
 #ifdef NDEF_USE_SERIAL
 

--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -194,6 +194,14 @@ boolean NfcAdapter::write(NdefMessage& ndefMessage)
     return success;
 }
 
+boolean NfcAdapter::enableRFField() {
+    return shield->setRFField(0, 1);
+}
+
+boolean NfcAdapter::disableRFField() {
+    return shield->setRFField(0, 0);
+}
+
 // TODO this should return a Driver MifareClassic, MifareUltralight, Type 4, Unknown
 // Guess Tag Type by looking at the ATQA and SAK values
 // Need to follow spec for Card Identification. Maybe AN1303, AN1305 and ???

--- a/NfcAdapter.h
+++ b/NfcAdapter.h
@@ -35,6 +35,10 @@ class NfcAdapter {
         boolean format();
         // reset tag back to factory state
         boolean clean();
+        // disable RF field
+        boolean enableRFField();
+        // enable RF field
+        boolean disableRFField();
     private:
         PN532* shield;
         byte uid[7];  // Buffer to store the returned UID


### PR DESCRIPTION
Fixed memory leak in NdefMessage
Added NfcAdapter::enableRFField() and NfcAdapter::disableRFField()
Return Error Tag on MifareCLassic read error