### PR TITLE
Fix crash on esp8266

### DIFF
--- a/MifareUltralight.cpp
+++ b/MifareUltralight.cpp
@@ -93,7 +93,7 @@ boolean MifareUltralight::isUnformatted()
 #ifdef NDEF_USE_SERIAL
         Serial.print(F("Error. Failed read page "));Serial.println(page);
 #endif
-        return false;
+        return true;
     }
 }
 


### PR DESCRIPTION
I'm not sure if it's correct but looking at the code it seems logical for `true` instead of `false` to be there. Since the name of the function is `isUnformatted` not `isFormatted...

Also it fixes crashing after certain number of readings with specific cards for me (esp8266).
E.g. on 2-d or sometimes on 3-d read of a 'bad' card esp8266 completely crashes and goes into reboot. This PR fixes it