### PR TITLE
Fix for partially read ultralight tag

### DIFF
--- a/MifareUltralight.cpp
+++ b/MifareUltralight.cpp
@@ -74,9 +74,11 @@ NfcTag MifareUltralight::read(byte * uid, unsigned int uidLength)
         index += ULTRALIGHT_PAGE_SIZE;
     }
 
-    NdefMessage ndefMessage = NdefMessage(&buffer[ndefStartIndex], messageLength);
-    return NfcTag(uid, uidLength, NFC_FORUM_TAG_TYPE_2, ndefMessage);
-
+    if(messageLength > 0){
+        NdefMessage ndefMessage = NdefMessage(&buffer[ndefStartIndex], messageLength);
+        return NfcTag(uid, uidLength, NFC_FORUM_TAG_TYPE_2, ndefMessage);
+    }
+    return NfcTag(uid, uidLength, NFC_FORUM_TAG_TYPE_2);
 }
 
 boolean MifareUltralight::isUnformatted()


### PR DESCRIPTION
In my use case, I found it relatively common to be able to retrieve partial NDEF messages, for example a tag with a URI ndef record of `https://example.com`, would often be returned as `http!I ⸮⸮  ⸮⸮  ⸮ ⸮`, due to reading uninitialized memory.

It seems to happen due to:
1) The `MifareUltralight::read` calls the `NdefMessage` constructor regardless of if the `messageLength` is `0`
2) Line 20 of the `NdefMessage::NdefMessage` constructor contains  `while (index <= numBytes)` - which does allow a partial NDEF message to be processed, even if `numBytes` is 0.

My fix is to not call the `NdefMessage` constructor if there was an error reading the message. 

It seems to make corrupted reads a thing of the past for me!