### PR TITLE
Support IRQ mode

### DIFF
--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -1,6 +1,6 @@
 #include <NfcAdapter.h>
 
-NfcAdapter::NfcAdapter(PN532Interface &interface, uint8_t irqPin = -1)
+NfcAdapter::NfcAdapter(PN532Interface &interface, uint8_t irqPin)
 {
     shield = new PN532(interface);
 

--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -1,8 +1,17 @@
 #include <NfcAdapter.h>
 
-NfcAdapter::NfcAdapter(PN532Interface &interface)
+NfcAdapter::NfcAdapter(PN532Interface &interface, uint8_t irqPin = -1)
 {
     shield = new PN532(interface);
+
+    //set the IRQ pin
+    _irqPin = irqPin;
+
+    // if defined, set the pin to input mode
+    if (irqPin > -1)
+    {
+        pinMode(irqPin, INPUT);
+    }
 }
 
 NfcAdapter::~NfcAdapter(void)
@@ -192,6 +201,20 @@ boolean NfcAdapter::write(NdefMessage& ndefMessage)
     }
 
     return success;
+}
+
+
+boolean NfcAdapter::startPassive()
+{
+    if (_irqPin > -1)
+    {
+        #ifdef NDEF_DEBUG
+        Serial.println(F("IRQ pin not specified"));
+        #endif
+        shield->startPassiveTargetIDDetection(PN532_MIFARE_ISO14443A);
+        return 1;
+    }
+    return 0;
 }
 
 // TODO this should return a Driver MifareClassic, MifareUltralight, Type 4, Unknown

--- a/NfcAdapter.h
+++ b/NfcAdapter.h
@@ -22,7 +22,7 @@
 
 class NfcAdapter {
     public:
-        NfcAdapter(PN532Interface &interface);
+        NfcAdapter(PN532Interface &interface, uint8_t irqPin = -1);
 
         ~NfcAdapter(void);
         void begin(boolean verbose=true);
@@ -35,9 +35,12 @@ class NfcAdapter {
         boolean format();
         // reset tag back to factory state
         boolean clean();
+        // enter passive detection mode (IRQ). For use with I2C ONLY.
+        boolean startPassive();
     private:
         PN532* shield;
         byte uid[7];  // Buffer to store the returned UID
+        uint8_t _irqPin; // stores the IRQ pin for I2C mode
         unsigned int uidLength; // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
         unsigned int guessTagType();
 };

--- a/examples/ReadTagIRQ/ReadTagIQR.ino
+++ b/examples/ReadTagIRQ/ReadTagIQR.ino
@@ -1,13 +1,18 @@
+/* -------------------------------------------------------------- */
+/*  This example uses the IRQ port on the PN532 which is only     */
+/*  available when the PN532 is in IRQ mode. It will not work in  */
+/*  other modes. You will need to connect the IRQ pin to an IO    */
+/* -------------------------------------------------------------- */
+
 #include <Wire.h>
 #include "PN532_I2C.h"
 #include "PN532.h"
 #include "NfcAdapter.h"
-#include "PN532Interface.h"
 
-#define CARD_DELAY    1000
-#define IRQ_PIN       14
+//how long to wait between card reads
+#define CARD_DELAY    1000  // wait 1s before reading another card
+#define IRQ_PIN       14    // pin the IRQ on the PN532 is connected to
 
-// IRQ only works in I2C mode for the PN532
 PN532_I2C pn532_i2c(Wire);
 NfcAdapter nfc = NfcAdapter(pn532_i2c, IRQ_PIN);
 
@@ -19,7 +24,7 @@ int irqPrev;
 void irqListen() {
   irqPrev = irqCurr = HIGH;
   nfc.startPassive();
-  Serial.println("\nScan a NFC tag\n");
+  Serial.println("Scan a NFC tag");
 }
 
 void readCard() {

--- a/examples/ReadTagIRQ/ReadTagIQR.ino
+++ b/examples/ReadTagIRQ/ReadTagIQR.ino
@@ -1,0 +1,55 @@
+#include <Wire.h>
+#include "PN532_I2C.h"
+#include "PN532.h"
+#include "NfcAdapter.h"
+#include "PN532Interface.h"
+
+#define CARD_DELAY    1000
+#define IRQ_PIN       14
+
+// IRQ only works in I2C mode for the PN532
+PN532_I2C pn532_i2c(Wire);
+NfcAdapter nfc = NfcAdapter(pn532_i2c, IRQ_PIN);
+
+long lastRead = 0;
+bool enabled = true;
+int irqCurr;
+int irqPrev;
+
+void irqListen() {
+  irqPrev = irqCurr = HIGH;
+  nfc.startPassive();
+  Serial.println("\nScan a NFC tag\n");
+}
+
+void readCard() {
+  if (nfc.tagPresent()) {
+    NfcTag tag = nfc.read();
+    tag.print();
+    lastRead = millis();
+  }
+  enabled = false;
+}
+
+void setup () {
+  Serial.begin(9600);
+  nfc.begin();
+  irqListen();
+}
+
+void loop () {
+  if (!enabled) {
+    if (millis() - lastRead > CARD_DELAY) {
+      enabled = true;
+      irqListen();
+    }
+  } else {
+    irqCurr = digitalRead(IRQ_PIN);
+
+    if (irqCurr == LOW && irqPrev == HIGH) {
+      readCard();
+    }
+  
+    irqPrev = irqCurr;
+  }
+}


### PR DESCRIPTION
To support non-blocking operation of the PN532, a new `startPassive()` function requests the PN532 to enter passive mode where the IRQ pin is pulled low when a card is detected at the reader. Usage is simple and an example is included on how to use this new function.

This code relies on the IRQ PR from the PN532 library:
https://github.com/Seeed-Studio/PN532/pull/115