### PR TITLE
added missing semicolon from NfcDriver.h class

### DIFF
--- a/NfcDriver.h
+++ b/NfcDriver.h
@@ -6,4 +6,4 @@ class NfcDriver
         virtual boolean write(NdefMessage& message, uint8_t * uid, int uidLength) = 0;
         // erase()
         // format()
-}
+};


### PR DESCRIPTION
I got an error when compiling due to a missing semicolon at the end of the NfcDriver.h class.