### PR TITLE
Add option to prevent halt when NFC tag not found on begin()

### DIFF
--- a/NfcAdapter.cpp
+++ b/NfcAdapter.cpp
@@ -10,7 +10,7 @@ NfcAdapter::~NfcAdapter(void)
     delete shield;
 }
 
-void NfcAdapter::begin(boolean verbose)
+bool NfcAdapter::begin(boolean verbose, boolean halt_on_not_found=true)
 {
     shield->begin();
 
@@ -21,7 +21,11 @@ void NfcAdapter::begin(boolean verbose)
 #ifdef NDEF_USE_SERIAL
         Serial.print(F("Didn't find PN53x board"));
 #endif
-        while (1); // halt
+        if (halt_on_not_found) {
+          while (1); // halt
+        } else {
+          return false;
+        }
     }
 
     if (verbose)
@@ -34,6 +38,7 @@ void NfcAdapter::begin(boolean verbose)
     }
     // configure board to read RFID tags
     shield->SAMConfig();
+    return true;
 }
 
 boolean NfcAdapter::tagPresent(unsigned long timeout)

--- a/NfcAdapter.h
+++ b/NfcAdapter.h
@@ -25,7 +25,7 @@ class NfcAdapter {
         NfcAdapter(PN532Interface &interface);
 
         ~NfcAdapter(void);
-        void begin(boolean verbose=true);
+        boolean begin(boolean verbose=true, boolean halt_on_not_found=true);
         boolean tagPresent(unsigned long timeout=0); // tagAvailable
         NfcTag read();
         boolean write(NdefMessage& ndefMessage);


### PR DESCRIPTION
I'm working on a project where an NFC reader may not always be attached. The current implementation of `begin()` halts if the device isn't found on init - this is kind of a dealbreaker for my use case.

So, my change adds an optional flag to `NfcAdapter::begin()` that allows the user to bypass the halt behavior. The behavior without specifying this flag is unchanged, so there should be no worry about backwards compatibility.

I've also made `begin()` return `true` if the NFC board was initialized, and `false` otherwise to aid in potential sensing / retry logic on the user side.

Thanks for maintaining this great repo :)